### PR TITLE
Applying Clean Code to a Function

### DIFF
--- a/app/src/main/java/com/example/sophia/mapthesong/MapsActivity.java
+++ b/app/src/main/java/com/example/sophia/mapthesong/MapsActivity.java
@@ -134,7 +134,25 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
 
     }
 
+    public byte[] readJsonFile(String fileAddress){
+      try {
+          InputStream is = getAssets().open(fileAddress);
 
+          int size = is.available();
+
+          byte[] buffer = new byte[size];
+
+          is.read(buffer);
+
+          is.close();
+
+          return buffer;
+
+      } catch (IOException ex) {
+          ex.printStackTrace();
+          Log.d("not happen", "sorry" );
+      }
+    }
 
     public ArrayList<City> getCitiesInWorld(String tracktitle){
 
@@ -143,26 +161,10 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
 
 
         String json = null;
-        try {
-            InputStream is = getAssets().open("data/tags1000.json");
-
-            int size = is.available();
-
-            byte[] buffer = new byte[size];
-
-            is.read(buffer);
-
-            is.close();
-
-            json = new String(buffer, "UTF-8");
-            Log.d("must happen", json );
-
-
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            Log.d("not happen", "sorry" );
+        json = new String(readJsonFile("data/tags1000.json"), "UTF-8");
+        if (json != null && !json.isEmpty()){
+          Log.d("must happen", json );
         }
-
 
         try {
             JSONArray  mArray = new JSONArray(json);


### PR DESCRIPTION
This Pull Request aims to make some small corrections applying the Clean Code book, it is also part of my final evaluation belonging to the class Best Practices of Coding from the degree in Software and Computer Engineering at the INFNET Institute having professor @leocamello as tutor.

[What was done]

- Create a function to read the json file, dividing the responsibility of the function getCitiesInWorld()

[Explanation and Evaluation of changes]
In the MapsActivity.java file you have a function called getCitiesInWorld (), in this function you can see that it's too large and could be broken down into other functions.

Exemplifying:
The following snippet can be inserted into a function that reads a file
json

``` Java
try {
  InputStream is = getAssets().open("data/tags1000.json");
  int size = is.available();
  byte[] buffer = new byte[size];
  is.read(buffer);
  is.close();
  json = new String(buffer, "UTF-8");
  Log.d("must happen", json );
} catch (IOException ex) {
  ex.printStackTrace();
  Log.d("not happen", "sorry" );
}
```
So the function it currently has would have only one function and would be
smaller and with only one responsibility.